### PR TITLE
Failed quizzes

### DIFF
--- a/src/components/Chat.tsx
+++ b/src/components/Chat.tsx
@@ -401,7 +401,7 @@ export const Chat: React.FC<{ isOpen: boolean; onClose: () => void }> = ({ isOpe
       style.id = styleId;
       style.innerHTML = `
         [class*="option"], [class*="answer"] {
-          color: white !important;
+          color: black !important;
           font-weight: 500 !important;
           border-radius: 6px !important;
           padding: 8px 12px !important;
@@ -415,8 +415,7 @@ export const Chat: React.FC<{ isOpen: boolean; onClose: () => void }> = ({ isOpe
         .option-prefix {
           color: #00FFFF !important;
           font-weight: bold !important;
-          font-size: 22px !important;
-          text-shadow: 0 0 8px rgba(0,255,255,0.9) !important;
+          font-size: 22px !important;          
         }
       `;
       document.head.appendChild(style);

--- a/src/components/Chat.tsx
+++ b/src/components/Chat.tsx
@@ -401,15 +401,22 @@ export const Chat: React.FC<{ isOpen: boolean; onClose: () => void }> = ({ isOpe
       style.id = styleId;
       style.innerHTML = `
         [class*="option"], [class*="answer"] {
-          color: #000 !important;
+          color: white !important;
           font-weight: 500 !important;
           border-radius: 6px !important;
           padding: 8px 12px !important;
           margin: 4px 0 !important;
+          font-size: 18px !important;
         }
         [class*="option"] code, [class*="answer"] code {
           color: white !important;
           background: transparent !important;
+        }
+        .option-prefix {
+          color: #00FFFF !important;
+          font-weight: bold !important;
+          font-size: 22px !important;
+          text-shadow: 0 0 8px rgba(0,255,255,0.9) !important;
         }
       `;
       document.head.appendChild(style);

--- a/src/components/MultipleChoiceOptions.tsx
+++ b/src/components/MultipleChoiceOptions.tsx
@@ -1,0 +1,74 @@
+import React from 'react';
+
+interface MultipleChoiceOptionsProps {
+  options: string[];
+  onAnswer: (optionIndex: number) => void;
+  disabled: boolean;
+  selectedAnswer?: number | null;
+  correctAnswer?: number | null;
+}
+
+// Improved MultipleChoiceOptions component with better styling
+const MultipleChoiceOptions: React.FC<MultipleChoiceOptionsProps> = ({
+  options,
+  onAnswer,
+  disabled,
+  selectedAnswer,
+  correctAnswer
+}) => {
+  
+  // Function to determine background color for each option
+  const getBackgroundColor = (idx: number) => {
+     return 'red';
+    if (selectedAnswer === null || selectedAnswer === undefined) return '#ffffffff'; // Match the screenshot
+    if (correctAnswer === idx) return '#4caf50';
+    if (selectedAnswer === idx && selectedAnswer !== correctAnswer) return '#f44336';
+    return '#ffffffff'; // Match the screenshot
+  };
+  
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: '8px' }}>
+      {/* {options.map((option, idx) => (
+        <button 
+          key={idx}
+          onClick={() => onAnswer(idx)}
+          disabled={disabled}
+          style={{
+            padding: '15px',
+            backgroundColor: getBackgroundColor(idx),
+            border: '1px solid #666', // Match the screenshot
+            borderRadius: '8px',
+            cursor: 'pointer',
+            textAlign: 'left',
+            fontSize: '16px',
+            color: 'white',
+            marginBottom: '12px',
+            boxShadow: '0 2px 8px rgba(0,0,0,0.5)', // Match the screenshot
+            width: '100%',
+            fontWeight: 500,
+            display: 'flex',
+            alignItems: 'center',
+            transition: 'all 0.2s ease' // Smooth transitions
+          }}
+        >
+          <span style={{
+            color: '#00FFFF', 
+            fontWeight: 'bold', 
+            marginRight: '12px', 
+            fontSize: '20px',
+            textShadow: '0 0 5px rgba(0,255,255,0.5)' // Glow effect
+          }}>
+            {`${String.fromCharCode(65+idx)})`}
+          </span>
+          <span style={{
+            fontSize: '16px',
+            fontWeight: 'normal',
+            color: 'white'
+          }}>{option}</span>
+        </button>
+      ))} */}
+    </div>
+  );
+};
+
+export default MultipleChoiceOptions;

--- a/src/pages/FailedQuestionsPrimer.tsx
+++ b/src/pages/FailedQuestionsPrimer.tsx
@@ -37,6 +37,8 @@ const processHtmlWithSyntaxHighlighting = (html: string) => {
         language={language}
         style={vscDarkPlus}
         showLineNumbers={false}
+        wrapLines={true}
+        wrapLongLines={true}
         customStyle={{
           margin: '12px 0',
           padding: '16px',
@@ -45,6 +47,9 @@ const processHtmlWithSyntaxHighlighting = (html: string) => {
           lineHeight: '1.4',
           borderRadius: '6px',
           fontFamily: "'Fira Code', 'Consolas', monospace",
+          whiteSpace: 'pre-wrap',
+          wordBreak: 'break-word',
+          overflowWrap: 'break-word'
         }}
       >
         {code}

--- a/src/pages/FailedQuizzes.tsx
+++ b/src/pages/FailedQuizzes.tsx
@@ -72,17 +72,59 @@ const FailedQuizzes: React.FC = () => {
       // Ensure explanation divs have white text color
       let processedHtml = quiz.html;
       
-      /// Add inline styles to explanation divs to ensure white text
-       processedHtml = processedHtml.replace(
-         /<div([^>]*class="[^"]*option[^"]*"[^>]*)>/gi,
-         '<div$1 style="color: white !important;">'
-       );
+      // First let's add option class if it's missing (ensuring we have something to target)
+      processedHtml = processedHtml.replace(
+        /<div>([A-D]\))/gi,
+        '<div class="option"><span class="option-prefix">$1</span>'
+      );
       
-      // // Also handle explanation paragraphs
-       processedHtml = processedHtml.replace(
-         /<p([^>]*class="[^"]*explanation[^"]*"[^>]*)>/gi,
-         '<p$1 style="color: white !important;">'
-       );
+      // Apply direct styles to options for guaranteed visibility
+      processedHtml = processedHtml.replace(
+        /<div class="option">/gi,
+        '<div class="option" style="padding: 15px !important; border: 1px solid #666 !important; border-radius: 8px !important; margin-bottom: 10px !important; background-color: #2A2A2A !important; color: white !important; display: block !important;">'
+      );
+      
+      // Style any existing options with more specific styling to override dark backgrounds
+      processedHtml = processedHtml.replace(
+        /<div([^>]*class="[^"]*option[^"]*"[^>]*)>/gi,
+        '<div$1 style="padding: 15px !important; border: 1px solid #666 !important; border-radius: 8px !important; margin-bottom: 10px !important; background-color: #2A2A2A !important; color: white !important; display: block !important;">'
+      );
+      
+      // Ensure option prefixes are properly styled with cyan color
+      processedHtml = processedHtml.replace(
+        /<span class="option-prefix">/gi, 
+        '<span class="option-prefix" style="color: #00FFFF !important; font-weight: bold !important; margin-right: 8px !important; display: inline-block !important;">'
+      );
+      
+      // Style any existing option prefixes with the correct styling
+      processedHtml = processedHtml.replace(
+        /<span([^>]*class="[^"]*option-prefix[^"]*"[^>]*)>/gi,
+        '<span$1 style="color: #00FFFF !important; font-weight: bold !important; margin-right: 8px !important; display: inline-block !important;">'
+      );
+      
+      // Make sure the options container has proper styling and spacing
+      processedHtml = processedHtml.replace(
+        /<div([^>]*class="[^"]*options[^"]*"[^>]*)>/gi,
+        '<div$1 style="padding-top: 10px !important; margin-bottom: 20px !important; display: block !important;">'
+      );
+      
+      // Target the div structure that might contain multiple choice options
+      processedHtml = processedHtml.replace(
+        /<div>([A-D])\)\s*(.*?)<\/div>/gi,
+        '<div class="option" style="padding: 15px !important; border: 1px solid #666 !important; border-radius: 8px !important; margin-bottom: 10px !important; background-color: #2A2A2A !important; color: white !important;"><span class="option-prefix" style="color: #00FFFF !important; font-weight: bold !important; margin-right: 8px !important;">$1)</span> $2</div>'
+      );
+      
+      // Enhance contrast for all question container
+      processedHtml = processedHtml.replace(
+        /<div class="question-container">/gi,
+        '<div class="question-container" style="color: white !important;">'
+      );
+      
+      // Also handle explanation paragraphs
+      processedHtml = processedHtml.replace(
+        /<p([^>]*class="[^"]*explanation[^"]*"[^>]*)>/gi,
+        '<p$1 style="color: white !important;">'
+      );
       
       // Handle any explanation content that might not have proper styling
       processedHtml = processedHtml.replace(
@@ -93,6 +135,19 @@ const FailedQuizzes: React.FC = () => {
           const whiteContent = content.replace(/<(p|div|span|h[1-6])([^>]*)>/gi, '<$1$2 style="color: white !important;">');
           return whiteOpeningTag + whiteContent + closingTag;
         }
+      );
+      
+      // Final fallback - if we have options that might not be captured by previous patterns
+      // This looks for patterns like A) Option text, even without proper classes
+      processedHtml = processedHtml.replace(
+        /<div[^>]*>\s*([A-D])\)\s*(.*?)<\/div>/gi,
+        '<div class="option" style="padding: 15px !important; border: 1px solid #666 !important; border-radius: 8px !important; margin-bottom: 10px !important; background-color: #2A2A2A !important; color: white !important;"><span style="color: #00FFFF !important; font-weight: bold !important; margin-right: 8px !important;">$1)</span> $2</div>'
+      );
+      
+      // Make sure the correct answer is highlighted
+      processedHtml = processedHtml.replace(
+        /<div class="correct-answer">/gi,
+        '<div class="correct-answer" style="color: #4caf50 !important; font-weight: bold !important; margin-bottom: 10px !important; font-size: 1.1rem !important; padding: 10px 0 !important; border-bottom: 1px solid #444 !important;">'
       );
       
       const quizMessage = {

--- a/src/pages/FailedQuizzes.tsx
+++ b/src/pages/FailedQuizzes.tsx
@@ -29,6 +29,7 @@ import { useChat } from '../contexts/chatContext';
 const FailedQuizzes: React.FC = () => {
   const { userFailedQuizzes, setUserFailedQuizzes, clearFailedQuizzes } = useQuiz();
   const { addExternalMessage } = useChat();
+
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
   const [quizToDelete, setQuizToDelete] = useState<number | null>(null);
   const [clearAllDialogOpen, setClearAllDialogOpen] = useState(false);
@@ -69,87 +70,73 @@ const FailedQuizzes: React.FC = () => {
 
   const handleViewFailedQuiz = (quiz: any) => {
     try {
-      // Ensure explanation divs have white text color
+      // Process the quiz.html string to apply styles and format code blocks
       let processedHtml = quiz.html;
-      
-      // First let's add option class if it's missing (ensuring we have something to target)
+
+      // Add option class if missing
       processedHtml = processedHtml.replace(
         /<div>([A-D]\))/gi,
         '<div class="option"><span class="option-prefix">$1</span>'
       );
-      
-      // Apply direct styles to options for guaranteed visibility
-      processedHtml = processedHtml.replace(
-        /<div class="option">/gi,
-        '<div class="option" style="padding: 15px !important; border: 1px solid #666 !important; border-radius: 8px !important; margin-bottom: 10px !important; background-color: #2A2A2A !important; color: white !important; display: block !important;">'
-      );
-      
-      // Style any existing options with more specific styling to override dark backgrounds
+
+      // Style options divs for visibility
       processedHtml = processedHtml.replace(
         /<div([^>]*class="[^"]*option[^"]*"[^>]*)>/gi,
         '<div$1 style="padding: 15px !important; border: 1px solid #666 !important; border-radius: 8px !important; margin-bottom: 10px !important; background-color: #2A2A2A !important; color: white !important; display: block !important;">'
       );
-      
-      // Ensure option prefixes are properly styled with cyan color
-      processedHtml = processedHtml.replace(
-        /<span class="option-prefix">/gi, 
-        '<span class="option-prefix" style="color: #00FFFF !important; font-weight: bold !important; margin-right: 8px !important; display: inline-block !important;">'
-      );
-      
-      // Style any existing option prefixes with the correct styling
+
+      // Style option prefixes with cyan color
       processedHtml = processedHtml.replace(
         /<span([^>]*class="[^"]*option-prefix[^"]*"[^>]*)>/gi,
         '<span$1 style="color: #00FFFF !important; font-weight: bold !important; margin-right: 8px !important; display: inline-block !important;">'
       );
-      
-      // Make sure the options container has proper styling and spacing
+
+     
+
       processedHtml = processedHtml.replace(
-        /<div([^>]*class="[^"]*options[^"]*"[^>]*)>/gi,
-        '<div$1 style="padding-top: 10px !important; margin-bottom: 20px !important; display: block !important;">'
-      );
-      
-      // Target the div structure that might contain multiple choice options
-      processedHtml = processedHtml.replace(
-        /<div>([A-D])\)\s*(.*?)<\/div>/gi,
-        '<div class="option" style="padding: 15px !important; border: 1px solid #666 !important; border-radius: 8px !important; margin-bottom: 10px !important; background-color: #2A2A2A !important; color: white !important;"><span class="option-prefix" style="color: #00FFFF !important; font-weight: bold !important; margin-right: 8px !important;">$1)</span> $2</div>'
-      );
-      
-      // Enhance contrast for all question container
-      processedHtml = processedHtml.replace(
-        /<div class="question-container">/gi,
-        '<div class="question-container" style="color: white !important;">'
-      );
-      
-      // Also handle explanation paragraphs
-      processedHtml = processedHtml.replace(
-        /<p([^>]*class="[^"]*explanation[^"]*"[^>]*)>/gi,
-        '<p$1 style="color: white !important;">'
-      );
-      
-      // Handle any explanation content that might not have proper styling
-      processedHtml = processedHtml.replace(
-        /(<div[^>]*class="[^"]*explanation[^"]*"[^>]*>)([\s\S]*?)(<\/div>)/gi,
-        (match: string, openingTag: string, content: string, closingTag: string) => {
-          // Add white color to the explanation div itself and all elements within it
-          const whiteOpeningTag = openingTag.replace('>', ' style="color: white !important;">');
-          const whiteContent = content.replace(/<(p|div|span|h[1-6])([^>]*)>/gi, '<$1$2 style="color: white !important;">');
-          return whiteOpeningTag + whiteContent + closingTag;
-        }
-      );
-      
-      // Final fallback - if we have options that might not be captured by previous patterns
-      // This looks for patterns like A) Option text, even without proper classes
-      processedHtml = processedHtml.replace(
-        /<div[^>]*>\s*([A-D])\)\s*(.*?)<\/div>/gi,
-        '<div class="option" style="padding: 15px !important; border: 1px solid #666 !important; border-radius: 8px !important; margin-bottom: 10px !important; background-color: #2A2A2A !important; color: white !important;"><span style="color: #00FFFF !important; font-weight: bold !important; margin-right: 8px !important;">$1)</span> $2</div>'
-      );
-      
-      // Make sure the correct answer is highlighted
+  /<pre[^>]*>\s*<code class="language-([^"]+)">([\s\S]*?)<\/code>\s*<\/pre>/gi,
+  (match: string, language: string, code: string) => {
+    const decodedCode = code
+      .replace(/&lt;/g, '<')
+      .replace(/&gt;/g, '>')
+      .replace(/&amp;/g, '&')
+      .replace(/&quot;/g, '"')
+      .replace(/&#x27;/g, "'");
+    return `\`\`\`${language}\n${decodedCode}\n\`\`\``;
+  }
+);
+
+processedHtml = processedHtml.replace(
+  /<code class="language-([^"]+)">([\s\S]*?)<\/code>/gi,
+  (match: string, language: string, code: string) => {
+    const decodedCode = code
+      .replace(/&lt;/g, '<')
+      .replace(/&gt;/g, '>')
+      .replace(/&amp;/g, '&')
+      .replace(/&quot;/g, '"')
+      .replace(/&#x27;/g, "'");
+    return `\`\`\`${language}\n${decodedCode}\n\`\`\``;
+  }
+);
+
+
+      // Additional styling fixes for other elements
       processedHtml = processedHtml.replace(
         /<div class="correct-answer">/gi,
         '<div class="correct-answer" style="color: #4caf50 !important; font-weight: bold !important; margin-bottom: 10px !important; font-size: 1.1rem !important; padding: 10px 0 !important; border-bottom: 1px solid #444 !important;">'
       );
-      
+
+      processedHtml = processedHtml.replace(
+        /<div class="question-container">/gi,
+        '<div class="question-container" style="color: white !important;">'
+      );
+
+      processedHtml = processedHtml.replace(
+        /<p([^>]*class="[^"]*explanation[^"]*"[^>]*)>/gi,
+        '<p$1 style="color: white !important;">'
+      );
+
+      // Prepare quiz message for adding to chat
       const quizMessage = {
         id: Math.random().toString(36).substring(7),
         text: processedHtml,
@@ -157,11 +144,10 @@ const FailedQuizzes: React.FC = () => {
         timestamp: new Date(),
         isFromLearnDialog: true,
         isSavedContent: true,
-        isViewingQuizContent: true,  // Enable syntax highlighting for code elements
+        isViewingQuizContent: true,
         savedContentType: 'Failed Quiz'
       };
-      
-      console.log('ReviewQuizzes - Viewing failed quiz:', quizMessage);
+
       addExternalMessage(quizMessage);
     } catch (e) {
       console.error('Error viewing failed quiz:', e);
@@ -169,119 +155,43 @@ const FailedQuizzes: React.FC = () => {
   };
 
   return (
-    <Container maxWidth="lg" sx={{ py: 4 }}>
-      <Box sx={{ mb: 4 }}>
-        <Typography
-          variant="h3"
-          component="h1"
-          sx={{
-            fontWeight: 'bold',
-            color: '#00ff00',
-            textAlign: 'center',
-            mb: 2,
-            textShadow: '0 0 10px rgba(0, 255, 0, 0.3)'
-          }}
-        >
-          Review Failed Quizzes
+    <Container maxWidth="lg" sx={{ mt: 4, mb: 4 }}>
+      <Box sx={{ mb: 2, display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+        <Typography variant="h5" sx={{ color: 'white' }}>
+          Failed Quizzes
         </Typography>
+        {userFailedQuizzes.length > 0 && (
+          <Button variant="outlined" color="error" onClick={handleClearAllClick}>
+            Clear All
+          </Button>
+        )}
       </Box>
 
-      {/* My Quizzes above Failed Quizzes */}
-      <Box>
-        <Box sx={{ mb: 4 }}>
-          <Typography variant="h4" sx={{ color: '#00ff00', fontWeight: 'bold', textAlign: 'center', mb: 2 }}>
-            My Quizzes
-          </Typography>
-          {/* You can add your My Quizzes table or content here */}
-        </Box>
-        {/* Failed Quizzes Section */}
-        {userFailedQuizzes.length === 0 ? (
-          <Paper
-            sx={{
-              maxWidth: 600,
-              mx: 'auto',
-              background: 'linear-gradient(135deg, rgba(102, 126, 234, 0.1) 0%, rgba(118, 75, 162, 0.1) 100%)',
-              border: '1px solid rgba(102, 126, 234, 0.2)',
-              borderRadius: 3,
-              boxShadow: '0 8px 32px rgba(0, 0, 0, 0.1)',
-              backdropFilter: 'blur(10px)',
-              p: 4,
-              textAlign: 'center'
-            }}
-          >
-            <QuizIcon sx={{ fontSize: 64, color: '#667eea', mb: 2 }} />
-            <Typography variant="h5" sx={{ color: '#667eea', mb: 2 }}>
-              No Failed Quizzes Yet
-            </Typography>
-            <Typography variant="body1" sx={{ color: 'text.secondary' }}>
-              When you get quiz questions wrong, they'll appear here for review and retake.
-            </Typography>
-          </Paper>
-        ) : (
-          <Box>
-            {/* Header with Clear All Button */}
-            <Box sx={{ 
-              display: 'flex', 
-              justifyContent: 'space-between', 
-              alignItems: 'center',
-              mb: 2
-            }}>
-              <Typography variant="h6" sx={{ color: 'text.primary' }}>
-                Failed Quizzes ({userFailedQuizzes.length})
-              </Typography>
-              <Button
-                variant="outlined"
-                color="error"
-                size="small"
-                onClick={handleClearAllClick}
-                sx={{
-                  borderColor: '#f44336',
-                  color: '#f44336',
-                  '&:hover': {
-                    borderColor: '#d32f2f',
-                    backgroundColor: 'rgba(244, 67, 54, 0.04)',
-                  }
-                }}
-              >
-                Clear All Failed Quizzes
-              </Button>
-            </Box>
-            
-            <TableContainer component={Paper} sx={{ 
-              borderRadius: 3,
-              boxShadow: '0 8px 32px rgba(0, 0, 0, 0.1)',
-              overflow: 'hidden'
-            }}>
-              <Table>
-              <TableHead sx={{ 
-                backgroundColor: '#0053ff'
-              }}>
+      {userFailedQuizzes.length === 0 ? (
+        <Typography sx={{ color: 'text.secondary' }}>No failed quizzes found.</Typography>
+      ) : (
+        <Box>
+          <TableContainer component={Paper} sx={{ backgroundColor: '#121212' }}>
+            <Table aria-label="failed quizzes table">
+              <TableHead>
                 <TableRow>
-                  <TableCell sx={{ color: 'white', fontWeight: 'bold' }}>
-                    Topic
-                  </TableCell>
-                  <TableCell sx={{ color: 'white', fontWeight: 'bold' }}>
-                    Skill Level
-                  </TableCell>
-                  <TableCell sx={{ color: 'white', fontWeight: 'bold' }}>
-                    Preview
-                  </TableCell>
-                  <TableCell sx={{ color: 'white', fontWeight: 'bold', textAlign: 'center' }}>
-                    Actions
-                  </TableCell>
+                  <TableCell sx={{ color: 'white' }}>Topic</TableCell>
+                  <TableCell sx={{ color: 'white' }}>Skill Level</TableCell>
+                  <TableCell sx={{ color: 'white' }}>Preview</TableCell>
+                  <TableCell sx={{ color: 'white', textAlign: 'center' }}>Actions</TableCell>
                 </TableRow>
               </TableHead>
+
               <TableBody>
                 {userFailedQuizzes.map((quiz, index) => {
-                  // Extract plain text from HTML for preview
                   const plainText = quiz.html.replace(/<[^>]*>/g, ' ').replace(/\s+/g, ' ').trim();
                   const preview = plainText.slice(0, 30) + (plainText.length > 30 ? '...' : '');
                   const tooltip = `Click to view quiz: ${plainText.slice(0, 100)}${plainText.length > 100 ? '...' : ''}`;
-                  
+
                   return (
-                    <TableRow 
+                    <TableRow
                       key={index}
-                      sx={{ 
+                      sx={{
                         backgroundColor: index % 2 === 0 ? '#000000' : '#424242',
                         '&:hover': {
                           backgroundColor: index % 2 === 0 ? '#1a1a1a' : '#525252'
@@ -292,16 +202,16 @@ const FailedQuizzes: React.FC = () => {
                         {quiz.topic}
                       </TableCell>
                       <TableCell>
-                        <Chip 
+                        <Chip
                           label={quiz.skillLevel}
                           size="small"
                           sx={{
-                            backgroundColor: 
-                              quiz.skillLevel.toLowerCase() === 'basic' || quiz.skillLevel.toLowerCase() === 'easy' 
-                                ? '#4caf50' 
+                            backgroundColor:
+                              quiz.skillLevel.toLowerCase() === 'basic' || quiz.skillLevel.toLowerCase() === 'easy'
+                                ? '#4caf50'
                                 : quiz.skillLevel.toLowerCase() === 'intermediate' || quiz.skillLevel.toLowerCase() === 'medium'
-                                ? '#ff9800'
-                                : '#f44336',
+                                  ? '#ff9800'
+                                  : '#f44336',
                             color: 'white',
                             fontWeight: 'bold'
                           }}
@@ -309,10 +219,10 @@ const FailedQuizzes: React.FC = () => {
                       </TableCell>
                       <TableCell sx={{ color: 'white' }}>
                         <Tooltip title={tooltip} arrow>
-                          <Typography 
-                            variant="body2" 
+                          <Typography
+                            variant="body2"
                             onClick={() => handleViewFailedQuiz(quiz)}
-                            sx={{ 
+                            sx={{
                               cursor: 'pointer',
                               fontFamily: 'monospace',
                               fontSize: '0.85rem',
@@ -366,15 +276,12 @@ const FailedQuizzes: React.FC = () => {
               </TableBody>
             </Table>
           </TableContainer>
-          </Box>
-        )}
-      </Box>
 
-      {userFailedQuizzes.length > 0 && (
-        <Box sx={{ mt: 3, textAlign: 'center' }}>
-          <Typography variant="body2" sx={{ color: 'text.secondary' }}>
-            Total Failed Quizzes: {userFailedQuizzes.length}
-          </Typography>
+          <Box sx={{ mt: 3, textAlign: 'center' }}>
+            <Typography variant="body2" sx={{ color: 'text.secondary' }}>
+              Total Failed Quizzes: {userFailedQuizzes.length}
+            </Typography>
+          </Box>
         </Box>
       )}
 

--- a/src/pages/FailedQuizzes.tsx
+++ b/src/pages/FailedQuizzes.tsx
@@ -82,7 +82,7 @@ const FailedQuizzes: React.FC = () => {
       // Style options divs for visibility
       processedHtml = processedHtml.replace(
         /<div([^>]*class="[^"]*option[^"]*"[^>]*)>/gi,
-        '<div$1 style="padding: 15px !important; border: 1px solid #666 !important; border-radius: 8px !important; margin-bottom: 10px !important; background-color: #2A2A2A !important; color: white !important; display: block !important;">'
+        '<div$1 style="border: 1px solid #666 !important; border-radius: 8px !important; margin-bottom: 10px !important; background-color: #2A2A2A !important; color: white !important; display: block !important;">'
       );
 
       // Style option prefixes with cyan color

--- a/src/pages/IWantToLearn.tsx
+++ b/src/pages/IWantToLearn.tsx
@@ -19,7 +19,7 @@ export const IWantToLearn: React.FC = () => {
   const navigate = useNavigate();
   const { setChatboxSkill, addExternalMessage } = useChat();
 
-  const handleLearnMore = async () => {
+  const handleLearnMore = async (useStudyAndLearn: boolean = false) => {
     if (!topic.trim()) return;
     
     setLoading(true);
@@ -31,7 +31,9 @@ export const IWantToLearn: React.FC = () => {
       const aiResponse = await chatService.explainTopicInDepth(
         "General Learning",
         topic,
-        "english"
+        "english",
+        false,
+        useStudyAndLearn
       );
       
       // Add AI response to chat
@@ -47,7 +49,7 @@ export const IWantToLearn: React.FC = () => {
 
   const handleKeyPress = (event: React.KeyboardEvent) => {
     if (event.key === 'Enter' && topic.trim() && !loading) {
-      handleLearnMore();
+      handleLearnMore(false);
     }
   };
 
@@ -145,35 +147,63 @@ export const IWantToLearn: React.FC = () => {
             </Box>
           )}
 
-          {/* Action Button */}
-          <Box sx={{ display: 'flex', justifyContent: 'center' }}>
+          {/* Action Buttons */}
+          <Box sx={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 2 }}>
             <Button
-              onClick={handleLearnMore}
+              onClick={() => handleLearnMore(false)}
               disabled={!topic.trim() || loading}
               variant="contained"
               size="large"
               sx={{
-              backgroundColor: '#1976D2',
-              color: 'white',
-              fontWeight: 'bold',
-              px: 6,
-              py: 1.5,
-              fontSize: '1.2rem',
-              borderRadius: 3,
-              textTransform: 'none',
-              '&:hover': { 
-                backgroundColor: '#1565C0',
-                transform: 'translateY(-2px)',
-                boxShadow: '0 5px 15px rgba(0,0,0,0.3)'
-              },
-              transition: 'all 0.2s ease-in-out',
-              '&:disabled': {
-                backgroundColor: 'rgba(25, 118, 210, 0.3)',
-                color: 'rgba(255, 255, 255, 0.5)'
-              }
-            }}
+                backgroundColor: '#1976D2',
+                color: 'white',
+                fontWeight: 'bold',
+                px: 6,
+                py: 1.5,
+                fontSize: '1.2rem',
+                borderRadius: 3,
+                textTransform: 'none',
+                '&:hover': { 
+                  backgroundColor: '#1565C0',
+                  transform: 'translateY(-2px)',
+                  boxShadow: '0 5px 15px rgba(0,0,0,0.3)'
+                },
+                transition: 'all 0.2s ease-in-out',
+                '&:disabled': {
+                  backgroundColor: 'rgba(25, 118, 210, 0.3)',
+                  color: 'rgba(255, 255, 255, 0.5)'
+                }
+              }}
             >
-              {loading ? 'Learning...' : 'Start Learning'}
+              {loading ? 'Start Learning' : 'Start Learning'}
+            </Button>
+            <Button
+              onClick={() => handleLearnMore(true)}
+              disabled={!topic.trim() || loading}
+              variant="contained"
+              size="large"
+              sx={{
+                backgroundColor: '#4CAF50',
+                color: 'white',
+                fontWeight: 'bold',
+                px: 6,
+                py: 1.5,
+                fontSize: '1.2rem',
+                borderRadius: 3,
+                textTransform: 'none',
+                '&:hover': { 
+                  backgroundColor: '#388E3C',
+                  transform: 'translateY(-2px)',
+                  boxShadow: '0 5px 15px rgba(0,0,0,0.3)'
+                },
+                transition: 'all 0.2s ease-in-out',
+                '&:disabled': {
+                  backgroundColor: 'rgba(76, 175, 80, 0.3)',
+                  color: 'rgba(255, 255, 255, 0.5)'
+                }
+              }}
+            >
+              {loading ? 'Study and Learn (OpenAI Beta)'  : 'Study and Learn (OpenAI Beta)'}
             </Button>
           </Box>
         </Box>

--- a/src/pages/MyQuizzes.tsx
+++ b/src/pages/MyQuizzes.tsx
@@ -194,8 +194,8 @@ const MyQuizzes: React.FC = () => {
         /(<div[^>]*class="[^\"]*explanation[^\"]*"[^>]*>)([\s\S]*?)(<\/div>)/gi,
         (match: string, openingTag: string, content: string, closingTag: string) => {
           // Add white color to the explanation div itself and all elements within it
-          const whiteOpeningTag = openingTag.replace('>', ' style="color: black !important;">');
-          const whiteContent = content.replace(/<(p|div|span|h[1-6])([^>]*)>/gi, '<$1$2 style="color: black !important;">');
+          const whiteOpeningTag = openingTag.replace('>', ' style="color: white !important;">');
+          const whiteContent = content.replace(/<(p|div|span|h[1-6])([^>]*)>/gi, '<$1$2 style="color: white !important;">');
           return whiteOpeningTag + whiteContent + closingTag;
         }
       );

--- a/src/pages/MyQuizzes.tsx
+++ b/src/pages/MyQuizzes.tsx
@@ -189,16 +189,16 @@ const MyQuizzes: React.FC = () => {
         '<p$1 style="color: white !important;">'
       );
 
-      // Handle any explanation content that might not have proper styling
-      processedHtml = processedHtml.replace(
-        /(<div[^>]*class="[^\"]*explanation[^\"]*"[^>]*>)([\s\S]*?)(<\/div>)/gi,
-        (match: string, openingTag: string, content: string, closingTag: string) => {
-          // Add white color to the explanation div itself and all elements within it
-          const whiteOpeningTag = openingTag.replace('>', ' style="color: white !important;">');
-          const whiteContent = content.replace(/<(p|div|span|h[1-6])([^>]*)>/gi, '<$1$2 style="color: white !important;">');
-          return whiteOpeningTag + whiteContent + closingTag;
-        }
-      );
+      // // Handle any explanation content that might not have proper styling
+      // processedHtml = processedHtml.replace(
+      //   /(<div[^>]*class="[^\"]*explanation[^\"]*"[^>]*>)([\s\S]*?)(<\/div>)/gi,
+      //   (match: string, openingTag: string, content: string, closingTag: string) => {
+      //     // Add white color to the explanation div itself and all elements within it
+      //     const whiteOpeningTag = openingTag.replace('>', ' style="color: white;">');
+      //     const whiteContent = content.replace(/<(p|div|span|h[1-6])([^>]*)>/gi, '<$1$2 style="color: white">');
+      //     return whiteOpeningTag + whiteContent + closingTag;
+      //   }
+      // );
 
       const quizMessage = {
         id: Math.random().toString(36).substring(7),

--- a/src/pages/MyQuizzes.tsx
+++ b/src/pages/MyQuizzes.tsx
@@ -148,26 +148,54 @@ const MyQuizzes: React.FC = () => {
     try {
       // Ensure options and explanation divs have white text color
       let processedHtml = quiz.html;
-      
+
+      // Convert <pre><code class="language-xxx">...</code></pre> blocks to Markdown triple-backtick format
+      processedHtml = processedHtml.replace(
+        /<pre[^>]*>\s*<code class="language-([^\"]+)">([\s\S]*?)<\/code>\s*<\/pre>/gi,
+        (match: string, language: string, code: string) => {
+          const decodedCode = code
+            .replace(/&lt;/g, '<')
+            .replace(/&gt;/g, '>')
+            .replace(/&amp;/g, '&')
+            .replace(/&quot;/g, '"')
+            .replace(/&#x27;/g, "'");
+          return `\`\`\`${language}\n${decodedCode}\n\`\`\``;
+        }
+      );
+
+      // Also handle <code class="language-xxx">...</code> blocks not wrapped in <pre>
+      processedHtml = processedHtml.replace(
+        /<code class="language-([^\"]+)">([\s\S]*?)<\/code>/gi,
+        (match: string, language: string, code: string) => {
+          const decodedCode = code
+            .replace(/&lt;/g, '<')
+            .replace(/&gt;/g, '>')
+            .replace(/&amp;/g, '&')
+            .replace(/&quot;/g, '"')
+            .replace(/&#x27;/g, "'");
+          return `\`\`\`${language}\n${decodedCode}\n\`\`\``;
+        }
+      );
+
       // Add inline styles to options to ensure white text
       processedHtml = processedHtml.replace(
-        /<div([^>]*class="[^"]*option[^"]*"[^>]*)>/gi,
+        /<div([^>]*class="[^\"]*option[^\"]*"[^>]*)>/gi,
         '<div$1 style="color: white !important;">'
       );
-      
+
       // Also handle explanation paragraphs
       processedHtml = processedHtml.replace(
-        /<p([^>]*class="[^"]*explanation[^"]*"[^>]*)>/gi,
+        /<p([^>]*class="[^\"]*explanation[^\"]*"[^>]*)>/gi,
         '<p$1 style="color: white !important;">'
       );
-      
+
       // Handle any explanation content that might not have proper styling
       processedHtml = processedHtml.replace(
-        /(<div[^>]*class="[^"]*explanation[^"]*"[^>]*>)([\s\S]*?)(<\/div>)/gi,
+        /(<div[^>]*class="[^\"]*explanation[^\"]*"[^>]*>)([\s\S]*?)(<\/div>)/gi,
         (match: string, openingTag: string, content: string, closingTag: string) => {
           // Add white color to the explanation div itself and all elements within it
-          const whiteOpeningTag = openingTag.replace('>', ' style="color: white !important;">');
-          const whiteContent = content.replace(/<(p|div|span|h[1-6])([^>]*)>/gi, '<$1$2 style="color: white !important;">');
+          const whiteOpeningTag = openingTag.replace('>', ' style="color: black !important;">');
+          const whiteContent = content.replace(/<(p|div|span|h[1-6])([^>]*)>/gi, '<$1$2 style="color: black !important;">');
           return whiteOpeningTag + whiteContent + closingTag;
         }
       );

--- a/src/pages/SkillsRefresher.tsx
+++ b/src/pages/SkillsRefresher.tsx
@@ -311,7 +311,9 @@ export const SkillsRefresher = () => {
                     }}
                   >
                     <MenuItem value="">
-                      <span style={{ fontSize: '18px', paddingRight: '4px' }}>🚀</span>
+                      <svg width="24" height="24" viewBox="0 0 24 24" style={{ marginRight: '4px' }}>
+                        <path d="M11 15H6l7-14v8h5l-7 14z" fill="#2196F3" stroke="black" strokeWidth="1" />
+                      </svg>
                     </MenuItem>
                     <MenuItem value="quiz" sx={{ color: 'white' }}>Quiz</MenuItem>
                     <MenuItem value="questions" sx={{ color: 'white' }}>Questions</MenuItem>

--- a/src/pages/SkillsRefresherDetail.tsx
+++ b/src/pages/SkillsRefresherDetail.tsx
@@ -472,6 +472,8 @@ export default function SkillsRefresherDetail({ onChatToggle, isChatOpen = false
             language={language}
             style={vscDarkPlus}
             showLineNumbers={false}
+            wrapLines={true}
+            wrapLongLines={true}
             customStyle={{
               margin: 0,
               padding: '16px',
@@ -481,6 +483,9 @@ export default function SkillsRefresherDetail({ onChatToggle, isChatOpen = false
               borderRadius: '6px',
               fontFamily: "'Fira Code', 'Consolas', monospace",
               color: '#d4d4d4',
+              whiteSpace: 'pre-wrap',
+              wordBreak: 'break-word',
+              overflowWrap: 'break-word'
             }}
           >
             {code}

--- a/src/pages/SkillsRefresherDetail.tsx
+++ b/src/pages/SkillsRefresherDetail.tsx
@@ -9,6 +9,7 @@ import { requestRefresher } from '../services/aiService';
 import { getYoutubeResources } from '../services/resourceService';
 import { Chat } from '../components/Chat';
 import { SubTopicsDialog } from '../components/SubTopicsDialog';
+import MultipleChoiceOptions from '../components/MultipleChoiceOptions';
 import { useChat } from '../contexts/chatContext';
 import { chatService } from '../services/chatService';
 import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter';
@@ -427,32 +428,35 @@ export default function SkillsRefresherDetail({ onChatToggle, isChatOpen = false
 
   // Simple function to render content with syntax highlighting
   const renderContentWithSyntaxHighlighting = (html: string) => {
-    // Extract code blocks and their info
+    // Extract code blocks and convert to React components for proper syntax highlighting
     const codeBlockRegex = /<pre><code class="language-([\w-]+)">([\s\S]*?)<\/code><\/pre>/g;
     const parts = [];
     let lastIndex = 0;
     let match;
-
+    
     while ((match = codeBlockRegex.exec(html)) !== null) {
-      // Add text before code block
+      // Add the text before this code block
       if (match.index > lastIndex) {
-        const textPart = html.slice(lastIndex, match.index);
         parts.push(
           <div 
-            key={`text-${parts.length}`}
-            dangerouslySetInnerHTML={{ __html: textPart }}
+            key={`text-${lastIndex}`} 
+            dangerouslySetInnerHTML={{ 
+              __html: html.slice(lastIndex, match.index) 
+            }} 
+            style={{ color: 'white' }}
           />
         );
       }
-
-      // Add syntax highlighted code block
+      
+      // Process language
       let language = match[1];
       // Prism-react-syntax-highlighter uses 'bash' for shell, but sometimes 'sh' or 'shell' is used
       if (language === 'shell') language = 'bash';
       if (language === 'sh') language = 'bash';
       // Prism-react-syntax-highlighter uses 'markup' for html
       if (language === 'html') language = 'markup';
-
+      
+      // Extract and decode the code
       const code = match[2]
         .replace(/&lt;/g, '<')
         .replace(/&gt;/g, '>')
@@ -460,42 +464,47 @@ export default function SkillsRefresherDetail({ onChatToggle, isChatOpen = false
         .replace(/&quot;/g, '"')
         .replace(/&#39;/g, "'")
         .trim();
-
+      
+      // Add the code block with syntax highlighting
       parts.push(
-        <SyntaxHighlighter
-          key={`code-${parts.length}`}
-          language={language}
-          style={vscDarkPlus}
-          showLineNumbers={false}
-          customStyle={{
-            margin: '12px 0',
-            padding: '16px',
-            background: '#1E1E1E',
-            fontSize: '18px',
-            lineHeight: '1.4',
-            borderRadius: '6px',
-            fontFamily: "'Fira Code', 'Consolas', monospace",
-          }}
-        >
-          {code}
-        </SyntaxHighlighter>
+        <Box key={`code-${match.index}`} sx={{ my: 2 }}>
+          <SyntaxHighlighter
+            language={language}
+            style={vscDarkPlus}
+            showLineNumbers={false}
+            customStyle={{
+              margin: 0,
+              padding: '16px',
+              background: '#1E1E1E',
+              fontSize: '16px',
+              lineHeight: '1.4',
+              borderRadius: '6px',
+              fontFamily: "'Fira Code', 'Consolas', monospace",
+              color: '#d4d4d4',
+            }}
+          >
+            {code}
+          </SyntaxHighlighter>
+        </Box>
       );
-
+      
       lastIndex = match.index + match[0].length;
     }
-
-    // Add remaining text after last code block
+    
+    // Add any remaining content after the last code block
     if (lastIndex < html.length) {
-      const remainingText = html.slice(lastIndex);
       parts.push(
         <div 
-          key={`text-${parts.length}`}
-          dangerouslySetInnerHTML={{ __html: remainingText }}
+          key={`text-${lastIndex}`} 
+          dangerouslySetInnerHTML={{ 
+            __html: html.slice(lastIndex) 
+          }} 
+          style={{ color: 'white' }}
         />
       );
     }
-
-    return parts;
+    
+    return <>{parts}</>;
   };
 
   const handleOptionChange = (event: React.ChangeEvent<HTMLInputElement>) => {
@@ -914,7 +923,7 @@ export default function SkillsRefresherDetail({ onChatToggle, isChatOpen = false
                 my: 3,
                 p: 3, 
                 borderRadius: 1,
-                backgroundColor: 'rgba(255, 255, 255, 0.05)', 
+                backgroundColor: 'rgba(0, 0, 0, 1)', 
                 '& .question-container': {
                   display: 'flex',
                   flexDirection: 'column',
@@ -953,7 +962,7 @@ export default function SkillsRefresherDetail({ onChatToggle, isChatOpen = false
                   '&.operator': { color: '#d4d4d4' }, 
                   '&.punctuation': { color: '#d4d4d4' }                },
                 '& a': { // Style for anchor tags
-                  color: 'primary.main',
+                  color: 'white',
                   textDecoration: 'underline',
                   '&:hover': {
                     color: 'primary.light',
@@ -1021,14 +1030,15 @@ export default function SkillsRefresherDetail({ onChatToggle, isChatOpen = false
                     <FormControlLabel 
                       key={option} 
                       value={option} 
-                      control={<Radio sx={{ color: 'primary.light', '&.Mui-checked': { color: 'secondary.main' } }} />} 
+                      control={<Radio sx={{ color: 'white', '&.Mui-checked': { color: 'white' } }} />} 
                       label={option} 
                       sx={{ 
-                        color: 'text.secondary',
+                        color: 'white',
                         cursor: 'pointer',
                         '&:hover': {
                           backgroundColor: 'rgba(255, 255, 255, 0.05)',
-                          borderRadius: 1
+                          color: 'white', 
+                          borderRadius: 1 
                         }
                       }}
                       onClick={() => {

--- a/src/services/aiService.ts
+++ b/src/services/aiService.ts
@@ -106,7 +106,8 @@ Supported language classes for <code class="language-xxx"> are: language-typescr
 10. Put each explanation point in the answer section on a new line using <p> tags.
 11. Make code examples practical and focused.
 12. Start off content with the question, don't return a summary of what you will do or a list of instructions. Just return the question and options, then the answer and explanation.;     
-13. Do not put any part of the answer outside the answer-box div.`
+13. Do not put any part of the answer outside the answer-box div.
+14. Try not to have lines longer than 80 characters for better readability.`
 
 prompt += `  Also!, quiz can't be similar to these previous ${previousQuizzes?.length} quizzes: ${previousQuizzes ? previousQuizzes.join(', Next Quiz:  ') : 'none'}.`;
 

--- a/src/services/aiService.ts
+++ b/src/services/aiService.ts
@@ -355,7 +355,6 @@ if (startCourse === 1) {
   }
 };
 
-
 // Food Saver AI call
 export const getFoodSaverResults = async (foodItem: string, city: string): Promise<string> => {
   try {

--- a/src/services/chatService.ts
+++ b/src/services/chatService.ts
@@ -252,6 +252,7 @@ If the user says "yes" after a check-in, expand with the next part of the lesson
 If the user says yes just assume they said next section and give appropriate content.`;
 
       var isCoderTestPrompt = isCoderTest ? ". Also feel free to offer alternate solutions to the quiz. ":  "";
+      // If isCoderTest is true, the assistant may offer alternate solutions to the quiz.
 
       const response = await fetch("https://openrouter.ai/api/v1/chat/completions", {
         method: "POST",

--- a/src/services/chatService.ts
+++ b/src/services/chatService.ts
@@ -248,7 +248,8 @@ You never rush or overwhelm.
 Make the learner feel comfortable and motivated.
 If the user asks for a quiz, provide it kindly and review answers with encouragement.
 If the user says they cannot answer, reassure them kindly, provide the answer, then offer to continue or review.
-If the user says "yes" after a check-in, expand with the next part of the lesson or ask what they want to learn next.`;
+If the user says "yes" after a check-in, expand with the next part of the lesson or ask what they want to learn next.
+If the user says yes just assume they said next section and give appropriate content.`;
 
       var isCoderTestPrompt = isCoderTest ? ". Also feel free to offer alternate solutions to the quiz. ":  "";
 

--- a/src/services/chatService.ts
+++ b/src/services/chatService.ts
@@ -223,7 +223,7 @@ When providing code examples or explanations:
     }
   }
   
-  async explainTopicInDepth(skill: string, topic: string, language: string = 'english', isCoderTest: boolean = false): Promise<ChatMessage> {
+  async explainTopicInDepth(skill: string, topic: string, language: string = 'english', isCoderTest: boolean = false, studyAndLearn: boolean = false): Promise<ChatMessage> {
     try {
       const apiKey = process.env.REACT_APP_OPENAI_API_KEY;
       
@@ -231,10 +231,26 @@ When providing code examples or explanations:
         throw new Error('API key not found in environment variables!');
       }
 
-      const prompt = `Explain the answer of this quiz in depth. The topic is ${skill}. 
+      let prompt = `Explain the answer of this quiz in depth. The topic is ${skill}. 
       At end link appropriate learning links about this topic.  The quiz is: ${topic}`;
 
-      var isCoderTestPrompt = isCoderTest ? ". Also feel free to offer alternate solutiosn to the quiz." : "";
+      if (studyAndLearn) prompt = `You are an interactive tutor. The user wants to learn ${topic}, 
+You are a warm, patient tutor guiding the user through a multi-step course on a topic.
+The course is divided into lessons. After explaining each lesson, check for understanding and wait for the user to say "continue" or similar to proceed.
+If the user requests a specific topic, switch to that lesson.
+If the user just says "yes" or "okay," continue to the next lesson in the sequence automatically.
+Do not overwhelm the user — keep lessons clear, simple, and concise.
+At each step, encourage questions and make the user feel comfortable.You are a warm, patient tutor guiding the user through a multi-step course on a topic.
+Your goal is to explain concepts clearly, use simple language, and encourage the learner every step of the way.
+Before moving on, you check if they understand by asking gentle, open-ended questions.
+If they seem confused, you provide additional explanations or examples.
+You never rush or overwhelm.
+Make the learner feel comfortable and motivated.
+If the user asks for a quiz, provide it kindly and review answers with encouragement.
+If the user says they cannot answer, reassure them kindly, provide the answer, then offer to continue or review.
+If the user says "yes" after a check-in, expand with the next part of the lesson or ask what they want to learn next.`;
+
+      var isCoderTestPrompt = isCoderTest ? ". Also feel free to offer alternate solutions to the quiz. ":  "";
 
       const response = await fetch("https://openrouter.ai/api/v1/chat/completions", {
         method: "POST",
@@ -243,7 +259,7 @@ When providing code examples or explanations:
           "Content-Type": "application/json"
         },
         body: JSON.stringify({
-          model: "anthropic/claude-3.5-sonnet",
+          model: studyAndLearn ? "openai/gpt-4.1" : "anthropic/claude-3.5-sonnet",
           temperature: 0.7,
           messages: [
             {

--- a/src/styles/answer-section.css
+++ b/src/styles/answer-section.css
@@ -32,15 +32,20 @@
   opacity: 100% !important;
   background-color: #000000 !important;
   border-radius: 4px !important;
-  overflow: auto !important;
+  overflow-x: hidden !important;
+  overflow-y: auto !important;
   border: 1px solid #333 !important;
   box-shadow: 0 2px 4px rgba(0,0,0,0.2) !important;
+  white-space: pre-wrap !important;
+  word-wrap: break-word !important;
 }
 
 .explanation code {
   font-family: "Fira Code", Consolas, monospace !important;
   font-size: 0.95rem !important;
   color: #ffffff !important;
+  white-space: pre-wrap !important;
+  word-wrap: break-word !important;
 }
 
 .content-block {
@@ -109,9 +114,12 @@
   padding: 20px !important;
   background-color: #000000 !important;
   border-radius: 4px !important;
-  overflow: auto !important;
+  overflow-x: hidden !important;
+  overflow-y: auto !important;
   border: 1px solid #333 !important;
   box-shadow: 0 2px 4px rgba(0,0,0,0.2) !important;
+  white-space: pre-wrap !important;
+  word-wrap: break-word !important;
 }
 
 .content-block code {

--- a/src/styles/answer-section.css
+++ b/src/styles/answer-section.css
@@ -157,8 +157,7 @@ div.options .option,
 [class*="option"].option {
   color: #fff !important;
   background-color: #333333 !important;
-  padding: 15px !important;
-  margin: 8px 0 !important;
+  
 }
 
 

--- a/src/styles/answer-section.css
+++ b/src/styles/answer-section.css
@@ -128,15 +128,31 @@
 
 
 .option-prefix {
-  color: cyan !important;
+  color: #00FFFF !important; /* Bright cyan */
+  font-weight: bold !important;
+  font-size: 20px !important;
+  margin-right: 10px !important;
+  
 }
 
 .options {
   padding-top: 0.3125rem !important;
   margin-bottom: 0 !important;
   padding-bottom: 0 !important;
-  display: block;
+  color: white !important;
+  display: block !important;
 }
+
+/* Higher specificity selector to override any other styling */
+div.options .option, 
+.quiz-question .option,
+[class*="option"].option {
+  color: #fff !important;
+  background-color: #333333 !important;
+  padding: 15px !important;
+  margin: 8px 0 !important;
+}
+
 
 .quiz-status {
   margin-top: 0 !important;
@@ -153,21 +169,28 @@
 }
 
 .option {
-    padding: 15px;
-    border: 1px solid #555;
-    border-radius: 8px;
-    cursor: pointer;
-    transition: background-color 0.3s, border-color 0.3s;
-    background-color: #1E1E1E; /* Dark background for options */
-    color: #fff; /* Light text for options */
+    padding: 15px !important;
+    border: 1px solid #666 !important;
+    border-radius: 8px !important;
+    cursor: pointer !important;
+    transition: all 0.3s ease !important;
+    background-color: #333333 !important; /* Match the second screenshot */
+    color: #fff !important; /* Light text for options */
+    margin-bottom: 10px !important;
+    margin-top: 0px !important;
+    box-shadow: 0 2px 8px rgba(0,0,0,0.5) !important;
+    font-size: 18px !important;
+    display: flex !important;
+    align-items: center !important;
   }
   
   .option:hover {
-    background-color: #333;
-    border-color: #777;
+    background-color: #444444 !important;
+    border-color: #999 !important;
+    box-shadow: 0 4px 12px rgba(0,255,255,0.2) !important;
   }
   
   .option.selected {
-    background-color: #007bff;
-    border-color: #0056b3;
+    background-color: #0066cc;
+    border-color: #0099ff;
   }


### PR DESCRIPTION
This pull request introduces a variety of UI and code improvements across several quiz-related pages and components. The main focus is on enhancing the display and formatting of quiz content, especially multiple-choice options and code blocks, and improving user interactions with failed and personal quizzes. There are also updates to button actions and visual styling to create a more consistent, readable, and interactive experience.

**Quiz Content Formatting & Display:**

* Improved handling of code blocks in quiz content by converting HTML `<pre><code>` and `<code>` blocks into Markdown triple-backtick format for better syntax highlighting in both failed and personal quizzes (`src/pages/FailedQuizzes.tsx`, `src/pages/MyQuizzes.tsx`). [[1]](diffhunk://#diff-52c348bcf07615c882b0b130c23996ddbf82fac1e13943423282ac1a4ecb61b0L72-L221) [[2]](diffhunk://#diff-c1cc5555054c4968a20e5a367513175de61198d7b3cc6c39504db0aa81bbecb1R152-R201)
* Enhanced styling for multiple-choice options, including color, font size, border radius, and a distinct cyan prefix for option labels (`src/components/Chat.tsx`, `src/components/MultipleChoiceOptions.tsx`). [[1]](diffhunk://#diff-530ed7d3bba918ebbd3f6970d4142bb0ac62c065099c6ca141d42a434a493029L404-R419) [[2]](diffhunk://#diff-6c43914ed6b1d3749892cb4bc190898499d77bb5a9fcedd78f83de24b64f5ed3R1-R74)

**Failed Quizzes Page Improvements:**

* Refactored the failed quizzes table for a cleaner dark theme and simplified messaging when no failed quizzes are present. Added a more prominent "Clear All" button and streamlined the layout (`src/pages/FailedQuizzes.tsx`). [[1]](diffhunk://#diff-52c348bcf07615c882b0b130c23996ddbf82fac1e13943423282ac1a4ecb61b0R32) [[2]](diffhunk://#diff-52c348bcf07615c882b0b130c23996ddbf82fac1e13943423282ac1a4ecb61b0L314-R285)
* Applied additional inline styles to quiz explanations, correct answers, and question containers for improved readability and visual separation (`src/pages/FailedQuizzes.tsx`).

**Learning Flow Updates:**

* Updated the "I Want To Learn" page to support two learning flows ("Start Learning" and "Study and Learn (OpenAI Beta)") via separate buttons and parameterized handler logic (`src/pages/IWantToLearn.tsx`). [[1]](diffhunk://#diff-e2c3c99430ab281b20408f4dc6725cd094a26b2f9ea1905901f4421d7b12558eL22-R22) [[2]](diffhunk://#diff-e2c3c99430ab281b20408f4dc6725cd094a26b2f9ea1905901f4421d7b12558eL34-R36) [[3]](diffhunk://#diff-e2c3c99430ab281b20408f4dc6725cd094a26b2f9ea1905901f4421d7b12558eL148-R153) [[4]](diffhunk://#diff-e2c3c99430ab281b20408f4dc6725cd094a26b2f9ea1905901f4421d7b12558eL176-R206)

**General UI Enhancements:**

* Improved code block rendering in the failed questions primer by enabling line wrapping and better word breaking for long lines (`src/pages/FailedQuestionsPrimer.tsx`). [[1]](diffhunk://#diff-7f9439c0de3c47d2dbdfb77fd25e9aaac49539037c0d8cbdda09dca933c25610R40-R41) [[2]](diffhunk://#diff-7f9439c0de3c47d2dbdfb77fd25e9aaac49539037c0d8cbdda09dca933c25610R50-R52)
* Updated the default icon for the skills refresher dropdown to a custom SVG rocket for better visual clarity (`src/pages/SkillsRefresher.tsx`).

**Component Integration:**

* Imported the new `MultipleChoiceOptions` component into the skills refresher detail page for future use (`src/pages/SkillsRefresherDetail.tsx`).